### PR TITLE
Allow the use of internal constructors for items under test

### DIFF
--- a/LeapingGorilla.Testing.Tests/LeapingGorilla.Testing.Tests.csproj
+++ b/LeapingGorilla.Testing.Tests/LeapingGorilla.Testing.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="WhenItemUnderTestHasNoPublicConstructor.cs" />
     <Compile Include="WhenItemUnderTestIsAbstract.cs" />
     <Compile Include="WhenItemUnderTestIsAnInterface.cs" />
+    <Compile Include="WhenItemUnderTestHasInternalConstructor.cs" />
     <Compile Include="WhenNoItemUnderTestOrGiven.cs" />
     <Compile Include="WhenTestingANullDependency.cs" />
     <Compile Include="WhenTestingANullDependencyForNullableValueType.cs" />

--- a/LeapingGorilla.Testing.Tests/WhenItemUnderTestHasInternalConstructor.cs
+++ b/LeapingGorilla.Testing.Tests/WhenItemUnderTestHasInternalConstructor.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LeapingGorilla.Testing.Attributes;
+using LeapingGorilla.Testing.Exceptions;
+using LeapingGorilla.Testing.Tests.Mocks;
+using NUnit.Framework;
+
+namespace LeapingGorilla.Testing.Tests
+{
+
+    public class ClassWithInternalConstructor
+    {
+        private ClassWithInternalConstructor() { }
+
+        internal ClassWithInternalConstructor(IMockLogger logger) { }
+    }
+    
+    public class WhenItemUnderTestHasInternalConstructor : WhenTestingTheBehaviourOf
+    {
+        [ItemUnderTest]
+        public ClassWithInternalConstructor Item;
+        
+        [Dependency]
+        public IMockLogger Logger { get; set; }
+
+        [Then]
+        public void SetupShouldCreateClass()
+        {
+            Assert.That(Item, Is.Not.Null);
+        }
+    }
+}

--- a/LeapingGorilla.Testing/WhenTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing/WhenTestingTheBehaviourOf.cs
@@ -175,8 +175,8 @@ namespace LeapingGorilla.Testing
 				constructorArguments[index] = dep.Value;
 			}
 
-				// Create the item under test and load it into the test class
-			accessor[this, itemUnderTest.Name] = Activator.CreateInstance(itemUnderTest.Type, constructorArguments);
+			// Create the item under test and load it into the test class
+			accessor[this, itemUnderTest.Name] = constructor.Invoke(constructorArguments);
 		}
 
 		private List<Dependency> CreateAndAssignPropertiesOrFieldsWithAttribute(TypeAccessor accessor, Type attributeType)
@@ -235,7 +235,11 @@ namespace LeapingGorilla.Testing
 				throw new ItemUnderTestCannotBeInterfaceStaticOrAbstract(itemUnderTestType);
 			}
 
-			var constructors = itemUnderTestType.GetConstructors();
+			// Look for Public or Internal Constructors
+			var constructors = itemUnderTestType
+                .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(c => c.IsPublic || c.IsAssembly);
+
 			if (constructors.All(c => c.IsPrivate))
 			{
 				throw new ItemUnderTestMustHavePublicConstructor(itemUnderTestType);


### PR DESCRIPTION
Because Unity gets confused when there are multiple constructors for a dependency, we need to often mark constructors used for testing as `internal`.  This PR adds support for targeting internal constructors for items under test.