### PR TITLE
Fixes an issue when subclassing with the composable pattern

### DIFF
--- a/LeapingGorilla.Testing.NUnit/Composable/ComposedThensFilter.cs
+++ b/LeapingGorilla.Testing.NUnit/Composable/ComposedThensFilter.cs
@@ -22,7 +22,14 @@ namespace LeapingGorilla.Testing.NUnit.Composable
 
         public bool IsMatch(Type type, MethodInfo method)
         {
-            return _composedThens.Any(x => x == method);
+            // HACK:
+            // We can't use a == or .Equals() to compare MethodInfo instances here even though this should be correct
+            // It is not exactly the same as this issue according to the provided repro but looks very similar
+            // https://github.com/dotnet/runtime/issues/6798.
+            // MethodHandle represents a pointer to the actual method in memory and it remains equal even if the
+            // MethodInfo instances themselves don't evaluate as equal.
+            
+            return _composedThens.Any(x => x.MethodHandle == method.MethodHandle);
         }
     }
 }

--- a/LeapingGorilla.Testing.Tests/Composable/WhenTestingComposableBddSubclass.cs
+++ b/LeapingGorilla.Testing.Tests/Composable/WhenTestingComposableBddSubclass.cs
@@ -1,0 +1,20 @@
+using LeapingGorilla.Testing.Core.Composable;
+
+namespace LeapingGorilla.Testing.NUnit.Tests.Composable;
+
+/// <summary>
+/// Verifies that subclassing works as expected. The previous implementation failed to find the Then methods
+/// unless they were in the same class.
+///
+/// See <see cref="LeapingGorilla.Testing.NUnit.Composable.ComposedThensFilter"/> for more details about the resolution.
+/// </summary>
+public class WhenTestingComposableBddSubclass : WhenTestingComposableBddHappyPath
+{
+    protected override ComposedTest ComposeTest() =>
+        TestComposer
+            .Given(SomeSetupIsPerformed)
+            .And(SomeMoreSetupIsPerformed)
+            .When(TheThingIsDone)
+            .Then(CheckTheThingWasCorrect)
+            .And(AnotherThingWasCorrect);
+}

--- a/LeapingGorilla.Testing.XUnit/Composable/ComposableTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing.XUnit/Composable/ComposableTestingTheBehaviourOf.cs
@@ -10,6 +10,17 @@ namespace LeapingGorilla.Testing.XUnit.Composable
     /// </summary>
     public abstract class ComposableTestingTheBehaviourOf : ComposableTestingTheBehaviourOfBase
     {
+        /// <summary>
+        /// Performs setup for this instance - this will prepare all mocks and request the test composition via the
+        /// ComposeTest() abstract method. Following this it will call the [Given] methods (if any) and then call the
+        /// [When] methods (if any). On completion the instance will be ready for the [Then] methods defined in the test
+        /// composition to be executed.
+        /// </summary>
+        /// <param name="shouldSetup">
+        /// Should we perform the setup step? Pass false to skip setup. If you skip setup you will
+        /// need to implement it yourself by calling the <see cref="ComposableTestingTheBehaviourOfBase.Setup">base.Setup()</see>
+        /// method.
+        /// </param>
         protected ComposableTestingTheBehaviourOf(bool shouldSetup = true)
         {
             if (shouldSetup)


### PR DESCRIPTION
When using NUnit with the composable pattern it was impossible to subclass a test class and use [Then] methods from the parent. NUnit would not display the test methods even though they were defined in `ComposeTest()`

This appears to be because of a bug in .NET with `MethodInfo` equality. From reading [this issue](https://github.com/dotnet/runtime/issues/6798) it appears that a `MethodInfo` object for a particular method should always be the same instance and therefore  `==` and `.Equals()` should return true.

During NUnit's test discovery the `MethodInfo` obtained via reflection is a different instance from the one provided as an `Action` via the test composition method. After digging deeper there is a `MethodHandle` property on the instance which references a pointer to the method in memory. This _is_ the same across the different instances so can be used as an alternative equality check.

I added an NUnit only test that was failing prior to this change and now passes, confirming the fix.