### PR TITLE
xUnit improvements

### DIFF
--- a/LeapingGorilla.Testing.NUnit/Attributes/ComposableBddAttribute.cs
+++ b/LeapingGorilla.Testing.NUnit/Attributes/ComposableBddAttribute.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Composable;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Composable;

--- a/LeapingGorilla.Testing.NUnit/Composable/ComposableTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing.NUnit/Composable/ComposableTestingTheBehaviourOf.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Composable;
 using LeapingGorilla.Testing.NUnit.Attributes;
 using NUnit.Framework;
@@ -14,9 +15,9 @@ namespace LeapingGorilla.Testing.NUnit.Composable
     public abstract class ComposableTestingTheBehaviourOf : ComposableTestingTheBehaviourOfBase
     {
         [OneTimeSetUp]
-        public override void Setup()
+        public override async Task SetupAsync()
         {
-            base.Setup();
+            await base.SetupAsync();
         }
     }
 }

--- a/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.NUnit.csproj
+++ b/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.NUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <Version>6.0.1</Version>
+      <Version>7.0.0</Version>
       <Description>BDD style testing framework to allow unit testing with automated mocking, dependency injection and minimum friction based on the NUnit testing library.
 
  We at Leaping Gorilla strive to remove as much friction as possible from our testing methodology. To that end we wanted a drop dead simple way to create unit tests that adhered to a few core principles:
@@ -23,7 +23,7 @@ From these needs LeapingGorilla.Testing was born.</Description>
       <PackageId>LeapingGorilla.Testing</PackageId>
       <Product>LeapingGorilla.Testing</Product>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-      <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>net6.0;net8.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.NUnit.csproj
+++ b/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.NUnit.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
       <Version>6.0.0</Version>
       <Description>BDD style testing framework to allow unit testing with automated mocking, dependency injection and minimum friction based on the NUnit testing library.
 
@@ -24,11 +23,12 @@ From these needs LeapingGorilla.Testing was born.</Description>
       <PackageId>LeapingGorilla.Testing</PackageId>
       <Product>LeapingGorilla.Testing</Product>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+      <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="NUnit" Version="3.13.2" />
-      <PackageReference Include="NSubstitute" Version="4.3.0" />
+      <PackageReference Include="NUnit" Version="4.1.0" />
+      <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.nuspec
+++ b/LeapingGorilla.Testing.NUnit/LeapingGorilla.Testing.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
     <metadata>
         <id>LeapingGorilla.Testing</id>
-        <version>6.0.1</version>
+        <version>7.0.0</version>
         <authors>Leaping Gorilla LTD</authors>
         <license type="expression">Apache-2.0</license>
         <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
@@ -25,20 +25,28 @@ From these needs LeapingGorilla.Testing was born.</description>
                 <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="System.Reflection.Emit.Lightweight" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="microsoft.csharp" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="nsubstitute" version="4.3.0" exclude="Build,Analyzers" />
-                <dependency id="NUnit" version="3.13.2" exclude="Build,Analyzers" />
+                <dependency id="nsubstitute" version="5.1.0" exclude="Build,Analyzers" />
+                <dependency id="NUnit" version="4.1.0" exclude="Build,Analyzers" />
               </group>
-              <group targetFramework=".NETStandard2.0">
+            <group targetFramework="net8.0">
                 <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="System.Reflection.Emit.Lightweight" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="microsoft.csharp" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="nsubstitute" version="4.3.0" exclude="Build,Analyzers" />
-                <dependency id="NUnit" version="3.13.2" exclude="Build,Analyzers" />
+                <dependency id="nsubstitute" version="5.1.0" exclude="Build,Analyzers" />
+                <dependency id="NUnit" version="4.1.0" exclude="Build,Analyzers" />
+            </group>
+              <group targetFramework="net462">
+                <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
+                <dependency id="System.Reflection.Emit.Lightweight" version="4.7.0" exclude="Build,Analyzers" />
+                <dependency id="microsoft.csharp" version="4.7.0" exclude="Build,Analyzers" />
+                <dependency id="nsubstitute" version="5.1.0" exclude="Build,Analyzers" />
+                <dependency id="NUnit" version="4.1.0" exclude="Build,Analyzers" />
               </group>
         </dependencies>
     </metadata>
     <files>
         <file src="bin\Release\net6.0\*.dll" target="lib\net6.0" />
-        <file src="bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+        <file src="bin\Release\net8.0\*.dll" target="lib\net8.0" />
+        <file src="bin\Release\net462\*.dll" target="lib\net462" />
     </files>
 </package>

--- a/LeapingGorilla.Testing.NUnit/WhenTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing.NUnit/WhenTestingTheBehaviourOf.cs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core;
 using NUnit.Framework;
 
@@ -25,9 +26,9 @@ namespace LeapingGorilla.Testing.NUnit
 	{
         /// <summary>Performs setup for this instance - this will prepare all mocks, call the [Given] methods (if any) and then call the [When] methods (if any), ready for your test assertions</summary>
 		[OneTimeSetUp]
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
-			base.Setup();
+			await base.SetupAsync();
 		}
 	}
 }

--- a/LeapingGorilla.Testing.Tests/LeapingGorilla.Testing.NUnit.Tests.csproj
+++ b/LeapingGorilla.Testing.Tests/LeapingGorilla.Testing.NUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>LeapingGorilla.Testing.NUnit.Tests</AssemblyName>
     <RootNamespace>LeapingGorilla.Testing.NUnit.Tests</RootNamespace>
   </PropertyGroup>
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LeapingGorilla.Testing.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
+++ b/LeapingGorilla.Testing.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -35,13 +36,12 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		public ClassWithNoPublicConstructor BadItem;
 
 		private Exception _setupException;
-
-
-		public override void Setup()
+		
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenItemUnderTestIsAbstract.cs
+++ b/LeapingGorilla.Testing.Tests/WhenItemUnderTestIsAbstract.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -30,13 +31,12 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		public AbstractClass BadItem;
 
 		private Exception _setupException;
-
-
-		public override void Setup()
+		
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenItemUnderTestIsAnInterface.cs
+++ b/LeapingGorilla.Testing.Tests/WhenItemUnderTestIsAnInterface.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -28,13 +29,12 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		public ICloneable BadItem;
 
 		private Exception _setupException;
-
-
-		public override void Setup()
+		
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingANullDependencyForNullableValueType.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingANullDependencyForNullableValueType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.NUnit.Attributes;
 using LeapingGorilla.Testing.NUnit.Tests.Mocks;
@@ -32,11 +33,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[NullDependency]
 		public int? Item;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingAttemptingToMockAnInvalidType.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingAttemptingToMockAnInvalidType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -30,11 +31,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[Mock]
 		public SimpleClassToTest BadMock { get; set; }
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithInvalidDependencies.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithInvalidDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -36,11 +37,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithMissingDependencies.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithMissingDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -30,11 +31,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[ItemUnderTest]
 		public SimpleClassToTest BadItem { get; set; }
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithNoItemUnderTest.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithNoItemUnderTest.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -32,11 +33,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[Dependency]
 		public IMockLogger MockLogger { get; set; }
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithWrongDependencies.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingDependencyInjectionWithWrongDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -33,11 +34,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[Dependency]
 		public IMockEventRaiser ThisShouldBeAMockLogger;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingMocking.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingMocking.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.NUnit.Attributes;
 using LeapingGorilla.Testing.NUnit.Tests.Mocks;
@@ -46,11 +47,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[Mock]
 		protected IMockLogger ProtectedPropertyMock { get; set; }
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingNullDependencyInjectionOnNonNullableType.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingNullDependencyInjectionOnNonNullableType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -29,11 +30,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 		[NullDependency]
 		public int Item;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAGivenMethodThatHasAReturnType.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAGivenMethodThatHasAReturnType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -26,11 +27,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 	{
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAGivenMethodWithParameters.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAGivenMethodWithParameters.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -26,11 +27,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 	{
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAWhenMethodThatHasAReturnType.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAWhenMethodThatHasAReturnType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -26,11 +27,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 	{
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAWhenMethodWithParameters.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingSetupWithAWhenMethodWithParameters.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -26,11 +27,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 	{
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.Tests/WhenTestingSetupWithTooManyWhenFields.cs
+++ b/LeapingGorilla.Testing.Tests/WhenTestingSetupWithTooManyWhenFields.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.NUnit.Attributes;
@@ -26,11 +27,11 @@ namespace LeapingGorilla.Testing.NUnit.Tests
 	{
 		private Exception _setupException;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/Composable/WhenRunningATestWithFailingSetup.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/Composable/WhenRunningATestWithFailingSetup.cs
@@ -1,0 +1,60 @@
+/*    
+   Copyright 2014-2024 Leaping Gorilla LTD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System;
+using LeapingGorilla.Testing.Core.Attributes;
+using LeapingGorilla.Testing.Core.Composable;
+using LeapingGorilla.Testing.XUnit.Attributes;
+using LeapingGorilla.Testing.XUnit.Composable;
+
+namespace LeapingGorilla.Testing.XUnit.Tests.Composable;
+
+public class WhenRunningATestWithFailingSetup : ComposableTestingTheBehaviourOf
+{
+    protected override ComposedTest ComposeTest() =>
+        TestComposer
+            .Given(SetupThrowsAnException)
+            .When(TheThingIsDone)
+            .Then(TestStillShowsAsAFailInTestExplorer);
+
+    [Given]
+    public void SetupThrowsAnException()
+    {
+        throw new Exception("Failing setup!");
+    }
+    
+    [When(true)]
+    public void TheThingIsDone()
+    {
+        Console.WriteLine("When invoked");
+    }
+
+    [Then(Skip = "Skipped so that there isn't a failing test in the results")]
+    public void TestStillShowsAsAFailInTestExplorer()
+    {
+        // Must be run manually by removing the skip. This is because the behaviour this test demonstrates
+        // necessitates a test failure so can't be included in the regular test run.
+        
+        // There is no failing assert causing the test failure. The test setup fails which presents as a
+        // failure of all the included [Then] methods within the class.
+        
+        // This test (when not skipped) demonstrates that failures in test setup don't cause the test
+        // to disappear from the test explorer. Previously the test setup was executed during [Then]
+        // discovery. This resulted in all [Then] methods within the class disappearing from the test
+        // explorer if there was an exception thrown from the setup. This behaviour is undesirable as
+        // it removes visibility of setup failures and makes debugging more difficult.
+    }
+}

--- a/LeapingGorilla.Testing.XUnit.Tests/LeapingGorilla.Testing.XUnit.Tests.csproj
+++ b/LeapingGorilla.Testing.XUnit.Tests/LeapingGorilla.Testing.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>LeapingGorilla.Testing.XUnit.Tests</AssemblyName>
         <RootNamespace>LeapingGorilla.Testing.XUnit.Tests</RootNamespace>
     </PropertyGroup>
@@ -13,7 +13,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit.runner.console" Version="2.7.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -36,16 +37,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-        public WhenItemUnderTestHasNoPublicConstructor() : base(false)
-        {
-			Setup();
-        }
-
-        public override void Setup()
+        public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
@@ -41,17 +41,23 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 			Setup();
         }
 
+#pragma warning disable xUnit1013 // This method doesn't need to be marked as Fact
         public new void Setup()
-		{
-			try
-			{
-				base.Setup();
-			}
-			catch (Exception ex)
-			{
-				_setupException = ex;
-			}
-		}
+        {
+	        try
+	        {
+#pragma warning disable CS0618 // Type or member is obsolete
+		        // Intentionally using obsolete method to verify
+		        // existing behaviour isn't broken
+		        base.Setup();
+#pragma warning restore CS0618 // Type or member is obsolete
+	        }
+	        catch (Exception ex)
+	        {
+		        _setupException = ex;
+	        }
+        }
+#pragma warning restore xUnit1013
 
 		[Then]
 		public void SetupShouldThrowAnException()

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestHasNoPublicConstructor.cs
@@ -15,7 +15,6 @@
 */
 
 using System;
-using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -37,11 +36,16 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-        public override async Task SetupAsync()
+        public WhenItemUnderTestHasNoPublicConstructor() : base(false)
+        {
+			Setup();
+        }
+
+        public new void Setup()
 		{
 			try
 			{
-				await base.SetupAsync();
+				base.Setup();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
@@ -36,17 +36,23 @@ namespace LeapingGorilla.Testing.XUnit.Tests
             Setup();
         }
 
-		public new void Setup()
-		{
+#pragma warning disable xUnit1013 // This method doesn't need to be marked as Fact
+        public new void Setup()
+        {
 			try
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
+				// Intentionally using obsolete method to verify
+				// existing behaviour isn't broken
 				base.Setup();
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 			catch (Exception ex)
 			{
 				_setupException = ex;
 			}
 		}
+#pragma warning restore xUnit1013
 
 		[Then]
 		public void SetupShouldThrowAnException()

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -31,16 +32,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-        public WhenItemUnderTestIsAbstract() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAbstract.cs
@@ -15,7 +15,6 @@
 */
 
 using System;
-using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -32,11 +31,16 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-		public override async Task SetupAsync()
+        public WhenItemUnderTestIsAbstract() : base(false)
+        {
+            Setup();
+        }
+
+		public new void Setup()
 		{
 			try
 			{
-				await base.SetupAsync();
+				base.Setup();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAnInterface.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenItemUnderTestIsAnInterface.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -29,17 +30,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-        public WhenItemUnderTestIsAnInterface() : base(false)
-        {
-            Setup();
-        }
-
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingANullDependencyForNullableValueType.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingANullDependencyForNullableValueType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.XUnit.Attributes;
 using LeapingGorilla.Testing.XUnit.Tests.Mocks;
@@ -32,11 +33,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[NullDependency]
 		public int? Item;
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingASealedTestClass.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingASealedTestClass.cs
@@ -1,0 +1,110 @@
+/*    
+   Copyright 2014-2024 Leaping Gorilla LTD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LeapingGorilla.Testing.Core.Attributes;
+using LeapingGorilla.Testing.Core.Composable;
+using LeapingGorilla.Testing.XUnit.Attributes;
+using LeapingGorilla.Testing.XUnit.Composable;
+using LeapingGorilla.Testing.XUnit.Exceptions;
+using LeapingGorilla.Testing.XUnit.XunitExtensions;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LeapingGorilla.Testing.XUnit.Tests;
+
+/// <summary>
+/// Replicates how xUnit invokes tests so we can validate that the correct exception is
+/// thrown if a test class is sealed.
+/// </summary>
+public class WhenTestingASealedTestClass : ComposableTestingTheBehaviourOf
+{
+    protected override ComposedTest ComposeTest() =>
+        TestComposer
+            .Given(LeapingGorillaTestInvokerConfiguredToBeInvokedForASealedClass)
+            .When(TestIsInvoked)
+            .Then(SealedClassExceptionIsThrown);
+    
+    public ExceptionAggregator ExceptionAggregator { get; set; }
+    public LeapingGorillaTestInvoker TestInvoker { get; set; }
+
+    [Given]
+    public void LeapingGorillaTestInvokerConfiguredToBeInvokedForASealedClass()
+    {
+        // Actual setup is performed in CreateManualDependencies() due to
+        // the class structure imposed by XunitTestInvoker
+    }
+		
+    [When]
+    public async Task TestIsInvoked()
+    {
+        await TestInvoker.RunAsync();
+    }
+
+    [Then]
+    public void SealedClassExceptionIsThrown()
+    {
+        Assert.True(ExceptionAggregator.HasExceptions);
+			
+        Assert.IsType<TestClassMustNotBeSealedException>(ExceptionAggregator.ToException());
+    }
+
+    protected override void CreateManualDependencies()
+    {
+        // Given the LeapingGorillaTestInvoker is configured to
+        // execute a sealed test class (SealedLgTestClass)...
+        
+        var test = Substitute.For<ITest>(); 
+        test.TestCase.Returns(new LeapingGorillaTestCase());
+			
+        var messageBus = Substitute.For<IMessageBus>();
+
+        var method = typeof(SealedLgTestClass)
+            .GetMethods()
+            .Single(x => x.Name == "AMethod");
+
+        ExceptionAggregator = new ExceptionAggregator();
+			
+        TestInvoker = new LeapingGorillaTestInvoker(
+            test,
+            messageBus,
+            typeof(SealedLgTestClass),
+            Array.Empty<object>(),
+            method,
+            Array.Empty<object>(),
+            Array.Empty<BeforeAfterTestAttribute>(),
+            ExceptionAggregator,
+            new CancellationTokenSource());
+    }
+}
+
+/// <summary>
+/// Sealed test class to facilitate the <see cref="WhenTestingASealedTestClass"/> test.
+/// Skipped by default so that the failure state doesn't occur. Unskip to see how this
+/// presents during a test run.
+/// </summary>
+public sealed class SealedLgTestClass : WhenTestingTheBehaviourOf
+{
+    [Then(Skip = "Unskip to see failed state")]
+    public void AMethod()
+    {
+    }
+}

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingAttemptingToMockAnInvalidType.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingAttemptingToMockAnInvalidType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -30,16 +31,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[Mock]
 		public SimpleClassToTest BadMock { get; set; }
 
-        public WhenTestingAttemptingToMockAnInvalidType() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithInvalidDependencies.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithInvalidDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -36,16 +37,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 
 		private Exception _setupException;
 
-        public WhenTestingDependencyInjectionWithInvalidDependencies() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithMissingDependencies.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithMissingDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -30,16 +31,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[ItemUnderTest]
 		public SimpleClassToTest BadItem { get; set; }
 
-        public WhenTestingDependencyInjectionWithMissingDependencies() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithNoItemUnderTest.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithNoItemUnderTest.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -32,16 +33,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[Dependency]
 		public IMockLogger MockLogger { get; set; }
 
-        public WhenTestingDependencyInjectionWithNoItemUnderTest() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithWrongDependencies.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingDependencyInjectionWithWrongDependencies.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -33,16 +34,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[Dependency]
 		public IMockEventRaiser ThisShouldBeAMockLogger;
 
-        public WhenTestingDependencyInjectionWithWrongDependencies() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingMocking.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingMocking.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.XUnit.Attributes;
 using LeapingGorilla.Testing.XUnit.Tests.Mocks;
@@ -46,11 +47,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[Mock]
 		protected IMockLogger ProtectedPropertyMock { get; set; }
 
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingNullDependencyInjectionOnNonNullableType.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingNullDependencyInjectionOnNonNullableType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -29,16 +30,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 		[NullDependency]
 		public int Item;
 
-        public WhenTestingNullDependencyInjectionOnNonNullableType() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupOnlyRunsOncePerClass.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupOnlyRunsOncePerClass.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using LeapingGorilla.Testing.Core.Attributes;
+using LeapingGorilla.Testing.XUnit.Attributes;
+using Xunit;
+
+namespace LeapingGorilla.Testing.XUnit.Tests;
+
+public class WhenTestingSetupOnlyRunsOncePerClass : WhenTestingTheBehaviourOf
+{
+    public static int SetupCount = 0;
+
+    [Given]
+    public void ThereIsSomeSetup()
+    {
+        // Record that setup has executed
+        Interlocked.Increment(ref SetupCount);
+    }
+
+    // Order isn't guaranteed but one of these will fail if the setup is executed
+    // for each [Then]. This is what happens by default with XUnit where every [Fact] 
+    // results in a new instance of the containing class to be created.
+    [Then]
+    public void FirstThen()
+    {
+        Assert.Equal(1, SetupCount);
+    }
+
+    [Then]
+    public void SecondThen()
+    {
+        Assert.Equal(1, SetupCount);
+    }
+}

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAGivenMethodThatHasAReturnType.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAGivenMethodThatHasAReturnType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -26,16 +27,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 	{
 		private Exception _setupException;
 
-        public WhenTestingSetupWithAGivenMethodThatHasAReturnType() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAGivenMethodWithParameters.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAGivenMethodWithParameters.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -26,16 +27,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 	{
 		private Exception _setupException;
 
-        public WhenTestingSetupWithAGivenMethodWithParameters() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAWhenMethodThatHasAReturnType.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAWhenMethodThatHasAReturnType.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -26,22 +27,17 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 	{
 		private Exception _setupException;
 
-        public WhenTestingSetupWithAWhenMethodThatHasAReturnType() : base(false)
+        public override async Task SetupAsync()
         {
-            Setup();
+	        try
+	        {
+		        await base.SetupAsync();
+	        }
+	        catch (Exception ex)
+	        {
+		        _setupException = ex;
+	        }
         }
-
-		public override void Setup()
-		{
-			try
-			{
-				base.Setup();
-			}
-			catch (Exception ex)
-			{
-				_setupException = ex;
-			}
-		}
 
 		[When]
 		public int BadWhenWithReturnType()

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAWhenMethodWithParameters.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithAWhenMethodWithParameters.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -26,16 +27,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 	{
 		private Exception _setupException;
 
-        public WhenTestingSetupWithAWhenMethodWithParameters() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithTooManyWhenFields.cs
+++ b/LeapingGorilla.Testing.XUnit.Tests/WhenTestingSetupWithTooManyWhenFields.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Attributes;
 using LeapingGorilla.Testing.Core.Exceptions;
 using LeapingGorilla.Testing.XUnit.Attributes;
@@ -26,16 +27,11 @@ namespace LeapingGorilla.Testing.XUnit.Tests
 	{
 		private Exception _setupException;
 
-        public WhenTestingSetupWithTooManyWhenFields() : base(false)
-        {
-            Setup();
-        }
-
-		public override void Setup()
+		public override async Task SetupAsync()
 		{
 			try
 			{
-				base.Setup();
+				await base.SetupAsync();
 			}
 			catch (Exception ex)
 			{

--- a/LeapingGorilla.Testing.XUnit/Composable/ComposableTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing.XUnit/Composable/ComposableTestingTheBehaviourOf.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core.Composable;
+using Xunit;
 
 namespace LeapingGorilla.Testing.XUnit.Composable
 {
@@ -8,8 +11,10 @@ namespace LeapingGorilla.Testing.XUnit.Composable
     /// Implementors should override the ComposeTest() method and perform other test setup as with
     /// <see cref="WhenTestingTheBehaviourOf"/> tests.
     /// </summary>
-    public abstract class ComposableTestingTheBehaviourOf : ComposableTestingTheBehaviourOfBase
+    public abstract class ComposableTestingTheBehaviourOf : ComposableTestingTheBehaviourOfBase, IAsyncLifetime
     {
+        private readonly bool _shouldSetup;
+        
         /// <summary>
         /// Performs setup for this instance - this will prepare all mocks and request the test composition via the
         /// ComposeTest() abstract method. Following this it will call the [Given] methods (if any) and then call the
@@ -18,15 +23,25 @@ namespace LeapingGorilla.Testing.XUnit.Composable
         /// </summary>
         /// <param name="shouldSetup">
         /// Should we perform the setup step? Pass false to skip setup. If you skip setup you will
-        /// need to implement it yourself by calling the <see cref="ComposableTestingTheBehaviourOfBase.Setup">base.Setup()</see>
+        /// need to implement it yourself by calling the <see cref="ComposableTestingTheBehaviourOfBase.SetupAsync">base.SetupAsync()</see>
         /// method.
         /// </param>
         protected ComposableTestingTheBehaviourOf(bool shouldSetup = true)
         {
-            if (shouldSetup)
+            _shouldSetup = shouldSetup;
+        }
+        
+        public virtual async Task InitializeAsync()
+        {
+            if (_shouldSetup)
             {
-                base.Setup();
+                await SetupAsync();
             }
+        }
+        
+        public virtual Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/LeapingGorilla.Testing.XUnit/Exceptions/TestClassMustNotBeSealedException.cs
+++ b/LeapingGorilla.Testing.XUnit/Exceptions/TestClassMustNotBeSealedException.cs
@@ -1,0 +1,34 @@
+/*    
+   Copyright 2014-2024 Leaping Gorilla LTD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System;
+
+namespace LeapingGorilla.Testing.XUnit.Exceptions
+{
+    /// <summary>
+    /// Exception raised when a test class using the xUnit version of Leaping Gorilla Testing is
+    /// marked as sealed.
+    /// Leaping Gorilla testing uses Castle dynamic proxies to support a single test class instance
+    /// for the whole scenario. Dynamic proxies cannot be created on sealed classes.
+    /// </summary>
+    public class TestClassMustNotBeSealedException : Exception
+    {
+        public TestClassMustNotBeSealedException(string className)
+            : base($"The Leaping Gorilla test class {className} cannot be sealed. Sealed test classes can only be used with the NUnit version of the library")
+        {
+        }
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.csproj
+++ b/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <Version>6.0.0</Version>
         <Description>BDD style testing framework to allow unit testing with automated mocking, dependency injection and minimum friction based on the XUnit testing library.
 
@@ -24,11 +23,12 @@ From these needs LeapingGorilla.Testing was born.</Description>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageId>LeapingGorilla.Testing.XUnit</PackageId>
         <Product>LeapingGorilla.Testing.XUnit</Product>
+        <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="NSubstitute" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.csproj
+++ b/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>6.0.1</Version>
+        <Version>7.0.0</Version>
         <Description>BDD style testing framework to allow unit testing with automated mocking, dependency injection and minimum friction based on the XUnit testing library.
 
  We at Leaping Gorilla strive to remove as much friction as possible from our testing methodology. To that end we wanted a drop dead simple way to create unit tests that adhered to a few core principles:
@@ -23,7 +23,7 @@ From these needs LeapingGorilla.Testing was born.</Description>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageId>LeapingGorilla.Testing.XUnit</PackageId>
         <Product>LeapingGorilla.Testing.XUnit</Product>
-        <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.nuspec
+++ b/LeapingGorilla.Testing.XUnit/LeapingGorilla.Testing.XUnit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
     <metadata>
         <id>LeapingGorilla.Testing.XUnit</id>
-        <version>6.0.1</version>
+        <version>7.0.0</version>
         <title>LeapingGorilla.Testing.XUnit</title>
         <authors>Leaping Gorilla LTD</authors>
         <owners>Leaping Gorilla LTD</owners>
@@ -24,24 +24,24 @@ From these needs LeapingGorilla.Testing was born.</description>
         <releaseNotes></releaseNotes>
         <copyright>Copyright Leaping Gorilla LTD ©  2013-2021</copyright>
         <dependencies>
-            <group targetFramework="net6.0">
+            <group targetFramework="net8.0">
                 <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="System.Reflection.Emit.Lightweight" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="microsoft.csharp" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="nsubstitute" version="4.3.0" exclude="Build,Analyzers" />
-                <dependency id="XUnit" version="2.4.1" exclude="Build,Analyzers" />
+                <dependency id="nsubstitute" version="5.1.0" exclude="Build,Analyzers" />
+                <dependency id="XUnit" version="2.7.0" exclude="Build,Analyzers" />
             </group>
             <group targetFramework=".NETStandard2.0">
                 <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="System.Reflection.Emit.Lightweight" version="4.7.0" exclude="Build,Analyzers" />
                 <dependency id="microsoft.csharp" version="4.7.0" exclude="Build,Analyzers" />
-                <dependency id="nsubstitute" version="4.3.0" exclude="Build,Analyzers" />
-                <dependency id="XUnit" version="2.4.1" exclude="Build,Analyzers" />
+                <dependency id="nsubstitute" version="5.1.0" exclude="Build,Analyzers" />
+                <dependency id="XUnit" version="2.7.0" exclude="Build,Analyzers" />
             </group>
         </dependencies>
     </metadata>
     <files>
-        <file src="bin\Release\net6.0\*.dll" target="lib\net6.0" />
+        <file src="bin\Release\net8.0\*.dll" target="lib\net8.0" />
         <file src="bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
     </files>
 </package>

--- a/LeapingGorilla.Testing.XUnit/ThenTestCaseDiscoverer.cs
+++ b/LeapingGorilla.Testing.XUnit/ThenTestCaseDiscoverer.cs
@@ -39,6 +39,7 @@ namespace LeapingGorilla.Testing.XUnit
             if (testClassUsesComposablePattern)
             {
                 TestComposer.ThrowOnValidationFailure = false;
+                
                 var testClassInstance = Activator.CreateInstance(testClassType) as ComposableTestingTheBehaviourOf;
                 
                 var composedTest = testClassInstance.ComposeTest();

--- a/LeapingGorilla.Testing.XUnit/WhenTestingTheBehaviourOf.cs
+++ b/LeapingGorilla.Testing.XUnit/WhenTestingTheBehaviourOf.cs
@@ -14,13 +14,17 @@
    limitations under the License.
 */
 
+using System.Threading.Tasks;
 using LeapingGorilla.Testing.Core;
+using Xunit;
 
 namespace LeapingGorilla.Testing.XUnit
 {
     /// <summary>Base class used for writing BDD style Given/When/Then unit tests for a component with simplified mocking semantics</summary>
-    public abstract class WhenTestingTheBehaviourOf : WhenTestingTheBehaviourOfBase
+    public abstract class WhenTestingTheBehaviourOf : WhenTestingTheBehaviourOfBase, IAsyncLifetime
 	{
+        private readonly bool _shouldSetup;
+
         /// <summary>
         /// Performs setup for this instance - this will prepare all mocks, call the [Given]
         /// methods (if any) and then call the [When] methods (if any), ready for your test
@@ -28,15 +32,25 @@ namespace LeapingGorilla.Testing.XUnit
         /// </summary>
         /// <param name="shouldSetup">
         /// Should we perform the setup step? Pass false to skip setup. If you skip setup you will
-        /// need to implement it yourself by calling the <see cref="WhenTestingTheBehaviourOfBase.Setup">base.Setup()</see>
+        /// need to implement it yourself by calling the <see cref="WhenTestingTheBehaviourOfBase.SetupAsync">base.SetupAsync()</see>
         /// method.
         /// </param>
         protected WhenTestingTheBehaviourOf(bool shouldSetup = true)
         {
-            if (shouldSetup)
+            _shouldSetup = shouldSetup;
+        }
+
+        public virtual async Task InitializeAsync()
+        {
+            if (_shouldSetup)
             {
-                base.Setup();
+                await SetupAsync();
             }
         }
-	}
+
+        public virtual Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaAsyncLifetimeInterceptor.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaAsyncLifetimeInterceptor.cs
@@ -1,4 +1,19 @@
-using System;
+/*    
+   Copyright 2014-2024 Leaping Gorilla LTD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaAsyncLifetimeInterceptor.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaAsyncLifetimeInterceptor.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+using Xunit;
+
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    /// <summary>
+    /// Used in conjunction with Castle dynamic proxies to control calls to the IAsyncLifetime
+    /// members. xUnit calls these methods before and after running each test but for LG tests
+    /// we have overriden the 'new class instance per test' behaviour. This interceptor ensures
+    /// that InitializeAsync/DisposeAsync are called only one time per test class. It also removes
+    /// the cached test class instance from the cache after disposing as it shouldn't be required
+    /// again.
+    /// </summary>
+    internal class LeapingGorillaAsyncLifetimeInterceptor : IInterceptor
+    {
+        private bool _alreadyInitialized = false;
+        private readonly List<MethodInfo> _expectedTestMethods;
+
+        public LeapingGorillaAsyncLifetimeInterceptor(IEnumerable<MethodInfo> expectedTestMethods)
+        {
+            _expectedTestMethods = new List<MethodInfo>(expectedTestMethods);
+        }
+        
+        public void Intercept(IInvocation invocation)
+        {
+            switch (invocation.Method.Name)
+            {
+                case nameof(IAsyncLifetime.InitializeAsync):
+                    InitializeIntercepted(invocation);
+                    break;
+                case nameof(IAsyncLifetime.DisposeAsync):
+                    DisposeAsyncIntercepted(invocation);
+                    break;
+                default:
+                    invocation.Proceed();
+                    break;
+            }
+        }
+
+        public void RecordTestMethodInvocation(MethodInfo testMethod)
+        {
+            lock (_expectedTestMethods)
+            {
+                _expectedTestMethods.Remove(testMethod);
+            }
+        }
+
+        private void InitializeIntercepted(IInvocation invocation)
+        {
+            // Prevents multiple initialization. By default xUnit creates a class instance per test
+            // case. We're now returning the same instance for multiple test cases but xUnit will
+            // still call InitializeAsync and DisposeAsync for every test.
+            if (_alreadyInitialized)
+            {
+                invocation.ReturnValue = Task.CompletedTask;
+            }
+            else
+            {
+                _alreadyInitialized = true;
+                invocation.Proceed();
+            }
+        }
+        
+        private void DisposeAsyncIntercepted(IInvocation invocation)
+        {
+            int expectedTestMethodCount;
+            lock (_expectedTestMethods)
+            {
+                expectedTestMethodCount = _expectedTestMethods.Count;
+            }
+            
+            if (expectedTestMethodCount == 0)
+            {
+                invocation.Proceed();
+                
+                // Remove test class instance from the cache as no more invocations are expected
+                LeapingGorillaTestInvoker.TestInstanceCache.TryRemove(invocation.Proxy.GetType().BaseType, out _);
+            }
+            else
+            {
+                invocation.ReturnValue = Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestCase.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestCase.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    /// <summary>
+    /// Custom test case class derived from XunitTestCase. This is required so that we can create a
+    /// chain of custom overrides that culminates in <see cref="LeapingGorillaTestInvoker"/>.
+    /// It also keeps a record of all the test methods in the associated test class which is required
+    /// for lifecycle management behaviour that is overriden.
+    /// </summary>
+    public class LeapingGorillaTestCase : XunitTestCase
+    {
+        public LeapingGorillaTestCase(IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            IEnumerable<MethodInfo> allTestMethodsInClass) : 
+                base(
+                    diagnosticMessageSink,
+                    defaultMethodDisplay,
+                    defaultMethodDisplayOptions,
+                    testMethod)
+        {
+            AllTestMethodsInClass = allTestMethodsInClass;
+        }
+
+        public IEnumerable<MethodInfo> AllTestMethodsInClass { get; private set; }
+
+        public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments,
+            ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new LeapingGorillaTestCaseRunner(this, this.DisplayName, this.SkipReason, constructorArguments, this.TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete - Obsolete inherited from xUnit base class
+        public LeapingGorillaTestCase() : base()
+        {
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestCaseRunner.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestCaseRunner.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    /// <summary>
+    /// Custom test case runner required by <see cref="LeapingGorillaTestCase" />
+    /// Overrides CreateTestRunner to return a <see cref="LeapingGorillaTestRunner" /> instance
+    /// </summary>
+    public class LeapingGorillaTestCaseRunner : XunitTestCaseRunner
+    {
+        public LeapingGorillaTestCaseRunner(
+            IXunitTestCase testCase,
+            string displayName,
+            string skipReason,
+            object[] constructorArguments,
+            object[] testMethodArguments,
+            IMessageBus messageBus,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource) :
+            base(
+                testCase,
+                displayName,
+                skipReason,
+                constructorArguments,
+                testMethodArguments,
+                messageBus,
+                aggregator,
+                cancellationTokenSource)
+        {
+        }
+        
+        protected override XunitTestRunner CreateTestRunner(ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments,
+            MethodInfo testMethod, object[] testMethodArguments, string skipReason, IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new LeapingGorillaTestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, new ExceptionAggregator(aggregator), cancellationTokenSource);
+        }
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestInvoker.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestInvoker.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Castle.DynamicProxy;
+using LeapingGorilla.Testing.XUnit.Composable;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    public class LeapingGorillaTestInvoker : XunitTestInvoker
+    {
+        public LeapingGorillaTestInvoker(ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod,
+            object[] testMethodArguments,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments,
+                beforeAfterAttributes,
+                aggregator,
+                cancellationTokenSource)
+        {
+        }
+
+        internal static readonly ConcurrentDictionary<Type, TestInstanceCacheItem> TestInstanceCache = new ConcurrentDictionary<Type, TestInstanceCacheItem>();
+        private static readonly ProxyGenerator Generator = new ProxyGenerator();
+        
+        protected override object CreateTestClass()
+        {
+            if (Test.TestCase is LeapingGorillaTestCase lgTestCase)
+            {
+                if (!TestInstanceCache.ContainsKey(TestClass))
+                {
+                    var interceptor = new LeapingGorillaAsyncLifetimeInterceptor(lgTestCase.AllTestMethodsInClass);
+                    var proxy = Generator.CreateClassProxy(TestClass, interceptor);
+                    TestInstanceCache.TryAdd(
+                        TestClass,
+                        new TestInstanceCacheItem
+                        {
+                            Interceptor = interceptor,
+                            Proxy = proxy
+                        });
+                }
+                
+                var cacheItem = TestInstanceCache[TestClass];
+                cacheItem.Interceptor.RecordTestMethodInvocation(TestMethod);
+                return cacheItem.Proxy;
+            }
+
+            return base.CreateTestClass();
+        }
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestInvoker.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestInvoker.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using Castle.DynamicProxy;
 using LeapingGorilla.Testing.XUnit.Composable;
+using LeapingGorilla.Testing.XUnit.Exceptions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -38,6 +39,10 @@ namespace LeapingGorilla.Testing.XUnit.XunitExtensions
             {
                 if (!TestInstanceCache.ContainsKey(TestClass))
                 {
+                    if (TestClass.IsSealed)
+                    {
+                        throw new TestClassMustNotBeSealedException(TestClass.Name);
+                    }
                     var interceptor = new LeapingGorillaAsyncLifetimeInterceptor(lgTestCase.AllTestMethodsInClass);
                     var proxy = Generator.CreateClassProxy(TestClass, interceptor);
                     TestInstanceCache.TryAdd(

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestRunner.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/LeapingGorillaTestRunner.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    /// <summary>
+    /// Custom test runner required by <see cref="LeapingGorillaTestCaseRunner" />
+    /// Overrides InvokeTestMethodAsync to invoke test method via a <see cref="LeapingGorillaTestInvoker" /> instance
+    /// </summary>
+    public class LeapingGorillaTestRunner : XunitTestRunner
+    {
+        public LeapingGorillaTestRunner(ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod,
+            object[] testMethodArguments,
+            string skipReason,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource) :
+            base(test,
+                messageBus,
+                testClass,
+                constructorArguments,
+                testMethod,
+                testMethodArguments,
+                skipReason,
+                beforeAfterAttributes,
+                aggregator,
+                cancellationTokenSource)
+        {
+        }
+        
+        protected override Task<Decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
+        {
+            return new LeapingGorillaTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource)
+                .RunAsync();
+        }
+    }
+}

--- a/LeapingGorilla.Testing.XUnit/XunitExtensions/TestInstanceCacheItem.cs
+++ b/LeapingGorilla.Testing.XUnit/XunitExtensions/TestInstanceCacheItem.cs
@@ -1,0 +1,14 @@
+namespace LeapingGorilla.Testing.XUnit.XunitExtensions
+{
+    /// <summary>
+    /// Stores a test class instance proxy and its associated interceptor so
+    /// that both can be accessed together.
+    /// <see cref="LeapingGorillaAsyncLifetimeInterceptor"/> for further information
+    /// on why the proxy and interceptors are required.
+    /// </summary>
+    internal struct TestInstanceCacheItem
+    {
+        public LeapingGorillaAsyncLifetimeInterceptor Interceptor { get; set; }
+        public object Proxy { get; set; }
+    }
+}

--- a/LeapingGorilla.Testing/Composable/ComposableTestingTheBehaviourOfBase.cs
+++ b/LeapingGorilla.Testing/Composable/ComposableTestingTheBehaviourOfBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace LeapingGorilla.Testing.Core.Composable
 {
@@ -10,20 +11,20 @@ namespace LeapingGorilla.Testing.Core.Composable
     /// </summary>
     public abstract class ComposableTestingTheBehaviourOfBase : WhenTestingTheBehaviourOfBase
     {
-        public override void Setup()
+        public override async Task SetupAsync()
         {
             var composedTest = ComposeTest();
 
             PrepareMocksDependenciesAndItemUnderTest();
-            ExecuteComposedGivenMethods(composedTest.GivenMethods);
-            ExecuteWhenMethod(composedTest.WhenMethod);
+            await ExecuteComposedGivenMethods(composedTest.GivenMethods);
+            await ExecuteWhenMethod(composedTest.WhenMethod);
         }
 
-        private void ExecuteComposedGivenMethods(IEnumerable<MethodInfo> composedTestGivens)
+        private async Task ExecuteComposedGivenMethods(IEnumerable<MethodInfo> composedTestGivens)
         {
             foreach (var method in composedTestGivens)
             {
-                InvokeMethodAsVoidOrTask(method);
+                await InvokeMethodAsVoidOrTask(method);
             }
         }
 

--- a/LeapingGorilla.Testing/Extensions/TypeExtensions.cs
+++ b/LeapingGorilla.Testing/Extensions/TypeExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace LeapingGorilla.Testing.Core.Extensions
+{
+    internal static class TypeExtensions
+    {
+        internal static IEnumerable<MethodInfo> GetMethodsWithAttribute(this Type classType, Type attributeType) {
+
+            return classType
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(mi => mi.IsDefined(attributeType, true));
+        }
+    }
+}

--- a/LeapingGorilla.Testing/LeapingGorilla.Testing.Core.csproj
+++ b/LeapingGorilla.Testing/LeapingGorilla.Testing.Core.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-        <AssemblyVersion>6.0.1.0</AssemblyVersion>
-        <FileVersion>6.0.1.0</FileVersion>
-        <Version>6.0.1</Version>
+        <TargetFrameworks>netstandard2.0;net8.0;net462</TargetFrameworks>
+        <AssemblyVersion>7.0.0.0</AssemblyVersion>
+        <FileVersion>7.0.0.0</FileVersion>
+        <Version>7.0.0</Version>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="microsoft.csharp" Version="4.7.0" />
-        <PackageReference Include="nsubstitute" Version="4.3.0" />
+        <PackageReference Include="nsubstitute" Version="5.1.0" />
         <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     </ItemGroup>

--- a/LeapingGorilla.Testing/LeapingGorilla.Testing.Core.csproj
+++ b/LeapingGorilla.Testing/LeapingGorilla.Testing.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;netstandard2.0;net8.0</TargetFrameworks>
         <AssemblyVersion>6.0.0.0</AssemblyVersion>
         <FileVersion>6.0.0.0</FileVersion>
         <Version>6.0.0</Version>

--- a/LeapingGorilla.Testing/WhenTestingTheBehaviourOfBase.cs
+++ b/LeapingGorilla.Testing/WhenTestingTheBehaviourOfBase.cs
@@ -48,9 +48,9 @@ namespace LeapingGorilla.Testing.Core
 		/// Invokes SetupAsync() synchronously.
 		/// </summary>
 		[Obsolete("Use SetupAsync() instead. Synchronous method relies on Task.Wait() which blocks the thread")]
-		public virtual void Setup()
+		public void Setup()
 		{
-			SetupAsync().Wait();
+			SetupAsync().GetAwaiter().GetResult();
 		}
 		
 		/// <summary>


### PR DESCRIPTION
Implements two improvements for xUnit

## Remove blocking `.Wait()` call during test setup

### Background
xUnit uses a `SynchronisationContext` that uses a fixed number of threads which by default matches the number of logical processors available on the machine. If any code calls the synchronous `.Wait()` method on a `Task` this blocks the executing thread and the rest of the async state machine will execute on one of the other synchronisation context threads.

This behaviour can cause a deadlock if there are enough tests with async methods in their setup. As xUnit runs multiple tests in parallel by default, it will run as many tests as there are logical processors in parallel. If all test threads block on `.Wait()` calls at the same time there will be no threads available to execute the rest of the code being waited on. All running tests will be waiting for a thread to be available and all threads will be blocked so none will _become_ available. When using await properly from end-to-end, threads aren't blocked during an await and are able run to completion.

### The change
xUnit supports asynchronous setup using the `IAsyncLifetime` interface on test classes. The base classes used for Leaping Gorilla tests now implement this interface and perform test setup asynchronously. If a test contains only synchronous setup it will still run synchronously as only completed tasks will be returned from the async setup methods. 

The existing synchronous `Setup()` method has been retained to avoid a breaking change for consumers but `SetupAsync()` should now be used instead if custom setup invocation is required. The legacy method still does a synchronous `.Wait()` so is vulnerable to the deadlock described above.

ℹ️ NUnit code was also updated to use an async method for setup but it isn't as affected by the `.Wait()` issue like xUnit so it's more of a no-op change.

## Use one test class instance for each Leaping Gorilla test scenario

### Background
xUnit creates a new test class instance for every `[Fact]` method by design. The Leaping Gorilla `[Then]` attribute extends `[Fact]`, so the existing behaviour is that a new test class instance is created for every `[Then]`. 

This isn't a problem behaviourally, but in some test scenarios e.g. integration testing where setup may be more expensive it can be a performance issue. The Leaping Gorilla test structure suits an approach where each concrete test class is constructed once per test run and multiple assertions are made on the state of objects within that instance.

### The change
The changes in this PR override the test run behaviour to fit this philosophy, specifically for Leaping Gorilla based tests. If any regular xUnit tests are included in the same test assembly they will execute as normal.

Key changes:
* Added `LeapingGorillaTestCase` which:
  * Identifies a test as a Leaping Gorilla test
  * Keeps a record of all the `[Then]` methods that make up the test class
  * Invokes tests using `LeapingGorillaTestCaseRunner`
* Added `LeapingGorillaTestInvoker` which is where the code ultimately ends up after being run via `LeapingGorillaTestCaseRunner`. This class does the following:
  * Keeps a cache of test class instances and returns the cached instances as required
  * Records which test methods have executed for each instance
  * Once all expected `[Then]` methods have executed, removes the instance from the cache
  * Uses dynamic proxies to intercept `IAsyncLifetime` method calls as they are called on every test method invocation and filters them to ensure they get invoked consistently with the class lifetime instead.